### PR TITLE
Add InsertDefaults method on *Schema

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -6,21 +6,22 @@
 
 package gojsonschema
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // InsertDefaults takes a map[string]interface{} and inserts any missing
 // default values specified in the JSON-Schema document.  If the given "into"
-// map is nil, it will be created.
+// map is nil, and default values exist, it will be created.
 //
 // This is an initial implementation which does not support refs, etc.
 // The target value must be an object and not a bare value.
-//
-// If called on a bad schema, this will panic.
-func (s *Schema) InsertDefaults(into map[string]interface{}) error {
-	properties, err := s.getDocProperties()
-	if err != nil {
-		return err
-	}
+func (s *Schema) InsertDefaults(into map[string]interface{}) (returnErr error) {
+	// Handle any panics caused by malformed schemas.
+	defer schemaPanicHandler(&returnErr)
+
+	properties := s.getDocProperties()
 
 	// Make sure the "into" map isn't nil.
 	if into == nil {
@@ -29,44 +30,48 @@ func (s *Schema) InsertDefaults(into map[string]interface{}) error {
 
 	// Now insert the default values at the keys in the "into" map,
 	// non-destructively.
-
 	iterateAndInsert(into, properties)
 
 	return nil
 }
 
+// schemaPanics catches panics caused by type assertions or gets on schemas
+// which have somehow slipped past validation.
+func schemaPanicHandler(err *error) {
+	if r := recover(); r != nil {
+		var msg string
+		switch t := r.(type) {
+		case error:
+			msg = fmt.Sprintf("schema error caused a panic: %s", t.Error())
+		default:
+			msg = fmt.Sprintf("unknown panic: %#v", t)
+		}
+		*err = errors.New(msg)
+	}
+}
+
 // getDocProperties retrieves the "properties" key of the standalone doc of
 // the schema.
-func (s *Schema) getDocProperties() (map[string]interface{}, error) {
-	// First, check for a missing document, since we will work with the
-	// raw document map.
-	if s.pool == nil {
-		return nil, errors.New("document pool for schema not set")
-	}
-
+//
+// Malformed schemas cause a panic.
+func (s *Schema) getDocProperties() map[string]interface{} {
 	f := s.pool.GetStandaloneDocument()
 
 	// We need a map[string]interface because we have to check for a
 	// default key.
-	docMap, ok := f.(map[string]interface{})
-	if !ok {
-		return nil, errors.New("schema document is not a map[string]interface{}")
-	}
+	docMap := f.(map[string]interface{})
 
-	// We need a schema with properties, since this feature does not support
-	// raw value schemas.
-	m, ok := docMap["properties"]
-	if !ok {
-		return nil, errors.New("schema document has no properties")
-	}
+	// We need a schema with properties, since this feature does not
+	// support raw value schemas.
+	m := docMap["properties"]
 
-	// Panic on bad schemas
-	typedMap := m.(map[string]interface{})
-	return typedMap, nil
+	return m.(map[string]interface{})
 }
 
 // iterateAndInsert takes a target map and inserts any missing default values
 // as specified in the properties map, according to JSON-Schema.
+//
+// Malformed schemas cause a panic.
 func iterateAndInsert(into, properties map[string]interface{}) {
 	for property, schema := range properties {
 		// Iterate over each key of the schema.  Each key should have

--- a/defaults.go
+++ b/defaults.go
@@ -1,0 +1,109 @@
+// Author: Bodie Solomon
+//         bodie@synapsegarden.net
+//         github.com/binary132
+//
+//         2015-02-16
+
+package gojsonschema
+
+import "errors"
+
+// InsertDefaults takes a map[string]interface{} and inserts any missing
+// default values specified in the JSON-Schema document.  If the given "into"
+// map is nil, it will be created.
+//
+// This is an initial implementation which does not support refs, etc.
+// The target value must be an object and not a bare value.
+//
+// If called on a bad schema, this will panic.
+func (s *Schema) InsertDefaults(into map[string]interface{}) error {
+	properties, err := s.getDocProperties()
+	if err != nil {
+		return err
+	}
+
+	// Make sure the "into" map isn't nil.
+	if into == nil {
+		into = make(map[string]interface{})
+	}
+
+	// Now insert the default values at the keys in the "into" map,
+	// non-destructively.
+
+	iterateAndInsert(into, properties)
+
+	return nil
+}
+
+// getDocProperties retrieves the "properties" key of the standalone doc of
+// the schema.
+func (s *Schema) getDocProperties() (map[string]interface{}, error) {
+	// First, check for a missing document, since we will work with the
+	// raw document map.
+	if s.pool == nil {
+		return nil, errors.New("document pool for schema not set")
+	}
+
+	f := s.pool.GetStandaloneDocument()
+
+	// We need a map[string]interface because we have to check for a
+	// default key.
+	docMap, ok := f.(map[string]interface{})
+	if !ok {
+		return nil, errors.New("schema document is not a map[string]interface{}")
+	}
+
+	// We need a schema with properties, since this feature does not support
+	// raw value schemas.
+	m, ok := docMap["properties"]
+	if !ok {
+		return nil, errors.New("schema document has no properties")
+	}
+
+	// Panic on bad schemas
+	typedMap := m.(map[string]interface{})
+	return typedMap, nil
+}
+
+// iterateAndInsert takes a target map and inserts any missing default values
+// as specified in the properties map, according to JSON-Schema.
+func iterateAndInsert(into, properties map[string]interface{}) {
+	for property, schema := range properties {
+		// Iterate over each key of the schema.  Each key should have
+		// a schema describing the key's properties.  If it does not,
+		// ignore this key.
+		typedSchema := schema.(map[string]interface{})
+
+		if v, ok := into[property]; ok {
+			// If there is already a map value in the target for
+			// this key, don't overwrite it; step in.  Ignore
+			// non-map values.
+			if innerMap, ok := v.(map[string]interface{}); ok {
+				// The schema should have an inner
+				// schema since it's an object
+				schemaProperties := typedSchema["properties"]
+				typedProperties := schemaProperties.(map[string]interface{})
+				iterateAndInsert(innerMap, typedProperties)
+			}
+			continue
+		}
+
+		if d, ok := typedSchema["default"]; ok {
+			// Most basic case: we have a default value. Done for
+			// this key.
+			into[property] = d
+			continue
+		}
+
+		if p, ok := typedSchema["properties"]; ok {
+			// If we have a "properties" key, this is an object,
+			// and we need to go deeper.
+			innerSchema := p.(map[string]interface{})
+			tmpTarget := make(map[string]interface{})
+			iterateAndInsert(tmpTarget, innerSchema)
+			if len(tmpTarget) > 0 {
+				into[property] = tmpTarget
+			}
+		}
+	}
+}

--- a/defaults_test.go
+++ b/defaults_test.go
@@ -9,18 +9,33 @@ package gojsonschema_test
 import (
 	"errors"
 	"fmt"
+	"log"
 	"testing"
 
 	gjs "github.com/juju/gojsonschema"
 	"github.com/stretchr/testify/assert"
 )
 
+func M(in ...interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+	if len(in)%2 != 0 {
+		log.Fatal("map construction M must have one value for each key")
+	}
+
+	for i := 0; i < len(in); i += 2 {
+		// Keys must be strings
+		k := in[i]
+		v := in[i+1]
+		sK := k.(string)
+		result[sK] = v
+	}
+
+	return result
+}
+
 // Get a *Schema given a properties map.
 func schemaFromProperties(t *testing.T, properties map[string]interface{}) *gjs.Schema {
-	schemaMap := map[string]interface{}{
-		"type":       "object",
-		"properties": properties,
-	}
+	schemaMap := M("type", "object", "properties", properties)
 	loader := gjs.NewGoLoader(schemaMap)
 	schema, err := gjs.NewSchema(loader)
 	assert.Nil(t, err)
@@ -32,7 +47,6 @@ func testGetDocProperties(schema *gjs.Schema) (doc map[string]interface{}, testE
 	defer func() {
 		if r := recover(); r != nil {
 			var msg string
-			// This should never panic
 			switch typed := r.(type) {
 			case error:
 				msg = fmt.Sprintf("panic: %s", typed.Error())
@@ -47,7 +61,7 @@ func testGetDocProperties(schema *gjs.Schema) (doc map[string]interface{}, testE
 }
 
 func TestGetDocProperties(t *testing.T) {
-	for i, test := range []struct {
+	tests := []struct {
 		should         string
 		usingSchema    interface{}
 		expectedErr    string
@@ -61,15 +75,15 @@ func TestGetDocProperties(t *testing.T) {
 		expectedErr: "interface conversion: interface is string, not map[string]interface {}",
 	}, {
 		should:      "panic for non schema document",
-		usingSchema: map[string]interface{}{"foo": "bar"},
+		usingSchema: M("foo", "bar"),
 		expectedErr: "interface conversion: interface is nil, not map[string]interface {}",
 	}, {
-		should: "work for an OK document",
-		usingSchema: map[string]interface{}{
-			"properties": map[string]interface{}{
-				"foo": "bar"}},
-		expectedResult: map[string]interface{}{"foo": "bar"},
-	}} {
+		should:         "work for an OK document",
+		usingSchema:    M("properties", M("foo", "bar")),
+		expectedResult: M("foo", "bar"),
+	}}
+
+	for i, test := range tests {
 		fmt.Printf("TestGetDocProperties test (%d) | should %s\n", i, test.should)
 		schema := gjs.MakeTestingSchema(test.usingSchema)
 		doc, err := testGetDocProperties(schema)
@@ -85,147 +99,67 @@ func TestGetDocProperties(t *testing.T) {
 }
 
 func TestIterateAndInsert(t *testing.T) {
-	for i, test := range []struct {
+	tests := []struct {
 		should          string
 		usingProperties map[string]interface{}
 		into            map[string]interface{}
 		expectedResult  map[string]interface{}
 	}{{
-		should: "insert value as expected for a simple default",
-		usingProperties: map[string]interface{}{
-			"num": map[string]interface{}{
-				"default": 5,
-				"type":    "integer",
-			}},
-		into:           map[string]interface{}{},
-		expectedResult: map[string]interface{}{"num": 5},
+		should:          "insert value as expected for a simple default",
+		usingProperties: M("num", M("default", 5, "type", "integer")),
+		into:            M(),
+		expectedResult:  M("num", 5),
 	}, {
-		should: "not overwrite existing values",
-		usingProperties: map[string]interface{}{
-			"num": map[string]interface{}{
-				"default": 5,
-				"type":    "integer",
-			}},
-		into:           map[string]interface{}{"num": 8},
-		expectedResult: map[string]interface{}{"num": 8},
+		should:          "not overwrite existing values",
+		usingProperties: M("num", M("default", 5, "type", "integer")),
+		into:            M("num", 8),
+		expectedResult:  M("num", 8),
 	}, {
-		should: "create a simple map with a default inner value",
-		usingProperties: map[string]interface{}{
-			"num": map[string]interface{}{
-				"properties": map[string]interface{}{
-					"dum": map[string]interface{}{
-						"default": 5,
-					}}}},
-		into: map[string]interface{}{},
-		expectedResult: map[string]interface{}{
-			"num": map[string]interface{}{
-				"dum": 5,
-			}},
+		should:          "create a simple map with a default inner value",
+		usingProperties: M("num", M("properties", M("dum", M("default", 5)))),
+		into:            M(),
+		expectedResult:  M("num", M("dum", 5)),
 	}, {
-		should: "non-destructively insert a value into an inner map",
-		usingProperties: map[string]interface{}{
-			"num": map[string]interface{}{
-				"properties": map[string]interface{}{
-					"dum": map[string]interface{}{
-						"default": 5,
-					}}}},
-		into: map[string]interface{}{
-			"num": map[string]interface{}{
-				"gum": 8,
-			}},
-		expectedResult: map[string]interface{}{
-			"num": map[string]interface{}{
-				"gum": 8,
-				"dum": 5,
-			}},
+		should:          "non-destructively insert a value into an inner map",
+		usingProperties: M("num", M("properties", M("dum", M("default", 5)))),
+		into:            M("num", M("gum", 8)),
+		expectedResult:  M("num", M("gum", 8, "dum", 5)),
 	}, {
-		should: "non-destructively insert a value into an inner map",
-		usingProperties: map[string]interface{}{
-			"num": map[string]interface{}{
-				"properties": map[string]interface{}{
-					"dum": map[string]interface{}{
-						"default": 5,
-					}}}},
-		into: map[string]interface{}{
-			"num": map[string]interface{}{
-				"gum": 8,
-			},
-			"foo": "bar",
-		},
-		expectedResult: map[string]interface{}{
-			"num": map[string]interface{}{
-				"gum": 8,
-				"dum": 5,
-			},
-			"foo": "bar",
-		},
+		should:          "non-destructively insert a value into an inner map",
+		usingProperties: M("num", M("properties", M("dum", M("default", 5)))),
+		into:            M("num", M("gum", 8), "foo", "bar"),
+		expectedResult:  M("num", M("gum", 8, "dum", 5), "foo", "bar"),
 	}, {
-		should: "non-destructively insert a value into an inner map",
-		usingProperties: map[string]interface{}{
-			"num": map[string]interface{}{
-				"properties": map[string]interface{}{
-					"dum": map[string]interface{}{
-						"default": 5,
-					},
-					"foo": map[string]interface{}{
-						"default": map[string]interface{}{
-							"bar": "baz",
-						}}}},
-			"foo": map[string]interface{}{
-				"properties": map[string]interface{}{
-					"bar": map[string]interface{}{
-						"default": "baz",
-					}}}},
-		into: map[string]interface{}{
-			"num": map[string]interface{}{
-				"gum": 8,
-			},
-			"foo": map[string]interface{}{},
-		},
-		expectedResult: map[string]interface{}{
-			"num": map[string]interface{}{
-				"gum": 8,
-				"dum": 5,
-				"foo": map[string]interface{}{"bar": "baz"},
-			},
-			"foo": map[string]interface{}{"bar": "baz"},
-		},
+		should: "non-destructively insert a complex default into an inner map",
+		usingProperties: M(
+			"num", M("properties",
+				M("dum", M("default", 5),
+					"foo", M("default", M("bar", "baz")))),
+			"foo", M("properties",
+				M("bar", M("default", "baz")))),
+		into: M("num", M("gum", 8), "foo", M()),
+		expectedResult: M(
+			"num", M("gum", 8, "dum", 5, "foo", M("bar", "baz")),
+			"foo", M("bar", "baz")),
 	}, {
 		should: "not insert a value if there is no default",
-		usingProperties: map[string]interface{}{
-			"num": map[string]interface{}{
-				"properties": map[string]interface{}{
-					"dum": map[string]interface{}{
-						"type":        "string",
-						"description": "something dum",
-					},
-					"foo": map[string]interface{}{
-						"default": map[string]interface{}{
-							"bar": "baz",
-						}}}},
-			"foo": map[string]interface{}{
-				"properties": map[string]interface{}{
-					"bar": map[string]interface{}{
-						"baz": map[string]interface{}{
-							"woz": map[string]interface{}{
-								"type": "integer",
-							}}}}}},
-		into: map[string]interface{}{},
-		expectedResult: map[string]interface{}{
-			"num": map[string]interface{}{
-				"foo": map[string]interface{}{"bar": "baz"},
-			}},
+		usingProperties: M(
+			"num", M("properties",
+				M("dum", M("type", "string",
+					"description", "something dum"),
+					"foo", M("default", M("bar", "baz")))),
+			"foo", M("properties",
+				M("bar", M("baz", M("woz", M("type", "integer")))))),
+		into:           M(),
+		expectedResult: M("num", M("foo", M("bar", "baz"))),
 	}, {
-		should: "ignore bad values",
-		usingProperties: map[string]interface{}{
-			"foo": map[string]interface{}{
-				"properties": map[string]interface{}{
-					"bar": map[string]interface{}{
-						"default": 5,
-					}}}},
-		into:           map[string]interface{}{"foo": 5},
-		expectedResult: map[string]interface{}{"foo": 5},
-	}} {
+		should:          "ignore bad values",
+		usingProperties: M("foo", M("properties", M("bar", M("default", 5)))),
+		into:            M("foo", 5),
+		expectedResult:  M("foo", 5),
+	}}
+
+	for i, test := range tests {
 		fmt.Printf("TestIterateAndInsert test (%d) | should %s\n", i, test.should)
 		gjs.IterateAndInsert(test.into, test.usingProperties)
 		assert.Equal(t, test.expectedResult, test.into)
@@ -235,7 +169,7 @@ func TestIterateAndInsert(t *testing.T) {
 }
 
 func TestDefaultObjects(t *testing.T) {
-	for i, test := range []struct {
+	tests := []struct {
 		should          string
 		usingProperties map[string]interface{}
 		into            map[string]interface{}
@@ -243,56 +177,38 @@ func TestDefaultObjects(t *testing.T) {
 		expectedError   string
 	}{{
 		should:          "have no problem with empty properties",
-		usingProperties: map[string]interface{}{},
+		usingProperties: M(),
 	}, {
 		should:          "handle panics from bad schemas gracefully",
-		usingProperties: map[string]interface{}{"foo": "bar"},
+		usingProperties: M("foo", "bar"),
 		expectedError:   "interface conversion: interface is string, not map[string]interface {}",
 	}, {
-		should: "work for simple schemas",
-		usingProperties: map[string]interface{}{
-			"foo": map[string]interface{}{"default": 5},
-		},
-		into: map[string]interface{}{"bar": 4},
-		expectedResult: map[string]interface{}{
-			"bar": 4,
-			"foo": 5,
-		},
+		should:          "work for simple schemas",
+		usingProperties: M("foo", M("default", 5)),
+		into:            M("bar", 4),
+		expectedResult:  M("bar", 4, "foo", 5),
 	}, {
-		should: "not overwrite values",
-		usingProperties: map[string]interface{}{
-			"foo": map[string]interface{}{"default": 5},
-		},
-		into:           map[string]interface{}{"foo": 4},
-		expectedResult: map[string]interface{}{"foo": 4},
+		should:          "not overwrite values",
+		usingProperties: M("foo", M("default", 5)),
+		into:            M("foo", 4),
+		expectedResult:  M("foo", 4),
 	}, {
 		should: "work for more complex schemas",
-		usingProperties: map[string]interface{}{
-			"num": map[string]interface{}{
-				"properties": map[string]interface{}{
-					"dum": map[string]interface{}{
-						"type":        "string",
-						"description": "dum",
-					},
-					"foo": map[string]interface{}{
-						"default": map[string]interface{}{
-							"bar": "baz",
-						}}}},
-			"foo": map[string]interface{}{
-				"properties": map[string]interface{}{
-					"bar": map[string]interface{}{
-						"baz": map[string]interface{}{
-							"woz": map[string]interface{}{
-								"type": "integer",
-							}}}}}},
-		into: map[string]interface{}{},
-		expectedResult: map[string]interface{}{
-			"num": map[string]interface{}{
-				"foo": map[string]interface{}{"bar": "baz"},
-			}},
-	}} {
+		usingProperties: M(
+			"num", M("properties", M(
+				"dum", M("type", "string", "description", "dum"),
+				"foo", M("default", M("bar", "baz")))),
+			"foo", M("properties", M(
+				"bar", M("properties", M(
+					"baz", M("properties", M(
+						"woz", M("type", "integer")))))))),
+		into:           M(),
+		expectedResult: M("num", M("foo", M("bar", "baz"))),
+	}}
+
+	for i, test := range tests {
 		fmt.Printf("TestDefaultObjects test (%d) | should %s\n", i, test.should)
-		schemaDoc := map[string]interface{}{"properties": test.usingProperties}
+		schemaDoc := M("properties", test.usingProperties)
 		schema := gjs.MakeTestingSchema(schemaDoc)
 		err := schema.InsertDefaults(test.into)
 		if test.expectedError != "" {

--- a/defaults_test.go
+++ b/defaults_test.go
@@ -11,8 +11,8 @@ import (
 	"fmt"
 	"testing"
 
+	gjs "github.com/juju/gojsonschema"
 	"github.com/stretchr/testify/assert"
-	gjs "github.com/xeipuuv/gojsonschema"
 )
 
 // Get a *Schema given a properties map.

--- a/defaults_test.go
+++ b/defaults_test.go
@@ -1,0 +1,235 @@
+// Author: Bodie Solomon
+//         bodie@synapsegarden.net
+//         github.com/binary132
+//
+//         2015-02-16
+
+package gojsonschema_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	gjs "github.com/xeipuuv/gojsonschema"
+)
+
+// Get a *Schema given a properties map.
+func schemaFromProperties(t *testing.T, properties map[string]interface{}) *gjs.Schema {
+	schemaMap := map[string]interface{}{
+		"type":       "object",
+		"properties": properties,
+	}
+	loader := gjs.NewGoLoader(schemaMap)
+	schema, err := gjs.NewSchema(loader)
+	assert.Nil(t, err)
+	return schema
+}
+
+func TestGetDocProperties(t *testing.T) {
+	for i, test := range []struct {
+		should         string
+		usingSchema    interface{}
+		expectedErr    string
+		expectedResult interface{}
+	}{{
+		should:      "fail for nil pool",
+		expectedErr: "document pool for schema not set",
+	}, {
+		should:      "fail for non-map document",
+		usingSchema: "not-a-map",
+		expectedErr: "schema document is not a map[string]interface{}",
+	}, {
+		should:      "fail for non schema document",
+		usingSchema: map[string]interface{}{"foo": "bar"},
+		expectedErr: "schema document has no properties",
+	}, {
+		should: "work for an OK document",
+		usingSchema: map[string]interface{}{"properties": map[string]interface{}{
+			"foo": "bar"}},
+		expectedResult: map[string]interface{}{"foo": "bar"},
+	}} {
+		fmt.Printf("TestGetDocProperties test (%d) | should %s\n", i, test.should)
+		schema := gjs.MakeTestingSchema(test.usingSchema)
+		doc, err := schema.GetDocProperties()
+		if test.expectedErr != "" {
+			assert.EqualError(t, err, test.expectedErr)
+			continue
+		}
+		assert.Equal(t, test.expectedResult, doc)
+	}
+
+	println()
+}
+
+func TestIterateAndInsert(t *testing.T) {
+	for i, test := range []struct {
+		should          string
+		usingProperties map[string]interface{}
+		into            map[string]interface{}
+		expectedResult  map[string]interface{}
+	}{{
+		should: "insert value as expected for a simple default",
+		usingProperties: map[string]interface{}{
+			"num": map[string]interface{}{
+				"default": 5,
+				"type":    "integer",
+			}},
+		into:           map[string]interface{}{},
+		expectedResult: map[string]interface{}{"num": 5},
+	}, {
+		should: "not overwrite existing values",
+		usingProperties: map[string]interface{}{
+			"num": map[string]interface{}{
+				"default": 5,
+				"type":    "integer",
+			}},
+		into:           map[string]interface{}{"num": 8},
+		expectedResult: map[string]interface{}{"num": 8},
+	}, {
+		should: "create a simple map with a default inner value",
+		usingProperties: map[string]interface{}{
+			"num": map[string]interface{}{
+				"properties": map[string]interface{}{
+					"dum": map[string]interface{}{
+						"default": 5,
+					}}}},
+		into: map[string]interface{}{},
+		expectedResult: map[string]interface{}{
+			"num": map[string]interface{}{
+				"dum": 5,
+			}},
+	}, {
+		should: "non-destructively insert a value into an inner map",
+		usingProperties: map[string]interface{}{
+			"num": map[string]interface{}{
+				"properties": map[string]interface{}{
+					"dum": map[string]interface{}{
+						"default": 5,
+					}}}},
+		into: map[string]interface{}{
+			"num": map[string]interface{}{
+				"gum": 8,
+			}},
+		expectedResult: map[string]interface{}{
+			"num": map[string]interface{}{
+				"gum": 8,
+				"dum": 5,
+			}},
+	}, {
+		should: "non-destructively insert a value into an inner map",
+		usingProperties: map[string]interface{}{
+			"num": map[string]interface{}{
+				"properties": map[string]interface{}{
+					"dum": map[string]interface{}{
+						"default": 5,
+					}}}},
+		into: map[string]interface{}{
+			"num": map[string]interface{}{
+				"gum": 8,
+			},
+			"foo": "bar",
+		},
+		expectedResult: map[string]interface{}{
+			"num": map[string]interface{}{
+				"gum": 8,
+				"dum": 5,
+			},
+			"foo": "bar",
+		},
+	}, {
+		should: "non-destructively insert a value into an inner map",
+		usingProperties: map[string]interface{}{
+			"num": map[string]interface{}{
+				"properties": map[string]interface{}{
+					"dum": map[string]interface{}{
+						"default": 5,
+					},
+					"foo": map[string]interface{}{
+						"default": map[string]interface{}{
+							"bar": "baz",
+						}}}},
+			"foo": map[string]interface{}{
+				"properties": map[string]interface{}{
+					"bar": map[string]interface{}{
+						"default": "baz",
+					}}}},
+		into: map[string]interface{}{
+			"num": map[string]interface{}{
+				"gum": 8,
+			},
+			"foo": map[string]interface{}{},
+		},
+		expectedResult: map[string]interface{}{
+			"num": map[string]interface{}{
+				"gum": 8,
+				"dum": 5,
+				"foo": map[string]interface{}{"bar": "baz"},
+			},
+			"foo": map[string]interface{}{"bar": "baz"},
+		},
+	}, {
+		should: "not insert a value if there is no default",
+		usingProperties: map[string]interface{}{
+			"num": map[string]interface{}{
+				"properties": map[string]interface{}{
+					"dum": map[string]interface{}{
+						"type":        "string",
+						"description": "something dum",
+					},
+					"foo": map[string]interface{}{
+						"default": map[string]interface{}{
+							"bar": "baz",
+						}}}},
+			"foo": map[string]interface{}{
+				"properties": map[string]interface{}{
+					"bar": map[string]interface{}{
+						"baz": map[string]interface{}{
+							"woz": map[string]interface{}{
+								"type": "integer",
+							}}}}}},
+		into: map[string]interface{}{},
+		expectedResult: map[string]interface{}{
+			"num": map[string]interface{}{
+				"foo": map[string]interface{}{"bar": "baz"},
+			}},
+	}, {
+		should: "ignore bad values",
+		usingProperties: map[string]interface{}{
+			"foo": map[string]interface{}{
+				"properties": map[string]interface{}{
+					"bar": map[string]interface{}{
+						"default": 5,
+					}}}},
+		into:           map[string]interface{}{"foo": 5},
+		expectedResult: map[string]interface{}{"foo": 5},
+	}} {
+		fmt.Printf("TestIterateAndInsert test (%d) | should %s\n", i, test.should)
+		gjs.IterateAndInsert(test.into, test.usingProperties)
+		assert.Equal(t, test.expectedResult, test.into)
+	}
+
+	println()
+}
+
+func TestDefaultObjects(t *testing.T) {
+	for i, test := range []struct {
+		should          string
+		usingProperties map[string]interface{}
+		usingParams     map[string]interface{}
+		expectedResult  map[string]interface{}
+		expectedError   string
+	}{} {
+		fmt.Printf("TestDefaultObjects test (%d) | should %s\n", i, test.should)
+		schema := schemaFromProperties(t, test.usingProperties)
+		err := schema.InsertDefaults(map[string]interface{}(test.usingParams))
+		if test.expectedError != "" {
+			assert.EqualError(t, err, test.expectedError)
+			continue
+		}
+		assert.Nil(t, err)
+		assert.Equal(t, test.expectedResult, test.usingParams)
+	}
+
+	println()
+}

--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,27 @@
+// Author: Bodie Solomon
+//         bodie@synapsegarden.net
+//         github.com/binary132
+//
+//         2015-02-16
+
+package gojsonschema
+
+// This returns a *Schema suitable for stubbing in defaults test, which only
+// cares about the pool document.
+func MakeTestingSchema(doc interface{}) *Schema {
+	var testingPool *schemaPool
+	if doc != nil {
+		testingPool = &schemaPool{standaloneDocument: doc}
+	}
+	return &Schema{pool: testingPool}
+}
+
+// This just uses the internal definition.
+func (s *Schema) GetDocProperties() (map[string]interface{}, error) {
+	return s.getDocProperties()
+}
+
+// Same
+func IterateAndInsert(into map[string]interface{}, properties map[string]interface{}) {
+	iterateAndInsert(into, properties)
+}

--- a/export_test.go
+++ b/export_test.go
@@ -6,8 +6,8 @@
 
 package gojsonschema
 
-// This returns a *Schema suitable for stubbing in defaults test, which only
-// cares about the pool document.
+// MakeTestingSchema returns a *Schema suitable for stubbing in defaults test,
+// which only cares about the pool document.
 func MakeTestingSchema(doc interface{}) *Schema {
 	var testingPool *schemaPool
 	if doc != nil {
@@ -16,12 +16,12 @@ func MakeTestingSchema(doc interface{}) *Schema {
 	return &Schema{pool: testingPool}
 }
 
-// This just uses the internal definition.
+// GetDocProperties uses the internal definition.
 func (s *Schema) GetDocProperties() map[string]interface{} {
 	return s.getDocProperties()
 }
 
-// Same
+// IterateAndInsert uses the internal definition.
 func IterateAndInsert(into map[string]interface{}, properties map[string]interface{}) {
 	iterateAndInsert(into, properties)
 }

--- a/export_test.go
+++ b/export_test.go
@@ -17,7 +17,7 @@ func MakeTestingSchema(doc interface{}) *Schema {
 }
 
 // This just uses the internal definition.
-func (s *Schema) GetDocProperties() (map[string]interface{}, error) {
+func (s *Schema) GetDocProperties() map[string]interface{} {
 	return s.getDocProperties()
 }
 

--- a/schema_test.go
+++ b/schema_test.go
@@ -337,5 +337,5 @@ func TestJsonSchemaTestSuite(t *testing.T) {
 
 	}
 
-	fmt.Printf("\n%d tests performed / %d total tests to perform ( %.2f %% )\n", len(JsonSchemaTestSuiteMap), 248, float32(len(JsonSchemaTestSuiteMap))/248.0*100.0)
+	fmt.Printf("\n%d tests performed / %d total tests to perform ( %.2f %% )\n\n", len(JsonSchemaTestSuiteMap), 248, float32(len(JsonSchemaTestSuiteMap))/248.0*100.0)
 }


### PR DESCRIPTION
This method is only useful for schemas defining objects, and will return
errors otherwise.  It does not handle refs.

Since this method should only be called on schemas defining objects, 
panics occur on malformed schemas.  It wraps panics in an error
passed back to the calling function.
